### PR TITLE
Add CA details view with certificate and chain parsing

### DIFF
--- a/src/app/api/ca/[id]/route.ts
+++ b/src/app/api/ca/[id]/route.ts
@@ -4,6 +4,94 @@ import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { AuditService } from '@/lib/audit';
 import { AuditAction } from '@prisma/client';
+import forge from 'node-forge';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    if (!id) {
+      return NextResponse.json({ error: 'CA id is required' }, { status: 400 });
+    }
+
+    const ca = await db.cAConfig.findUnique({ where: { id } });
+    if (!ca) {
+      return NextResponse.json({ error: 'CA not found' }, { status: 404 });
+    }
+
+    // Derive certificate details using forge (best effort)
+    let certInfo: any = null;
+    let chainInfo: any = null;
+    try {
+      if (ca.certificate) {
+        const cert = forge.pki.certificateFromPem(ca.certificate);
+        const subjectCN = cert.subject.getField('CN')?.value || null;
+        const issuerCN = cert.issuer.getField('CN')?.value || null;
+        const selfSigned = subjectCN && issuerCN && subjectCN === issuerCN;
+
+        certInfo = {
+          subjectCN,
+          issuerCN,
+          selfSigned,
+          notBefore: cert.validity.notBefore,
+          notAfter: cert.validity.notAfter,
+          publicKeyType: cert.publicKey?.type || null,
+        };
+      }
+    } catch {}
+
+    try {
+      if (ca.certificateChain) {
+        const regex = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+        const blocks = ca.certificateChain.match(regex) || [];
+        const parsed = blocks.map((b) => {
+          try {
+            const c = forge.pki.certificateFromPem(b);
+            return {
+              subjectCN: c.subject.getField('CN')?.value || null,
+              issuerCN: c.issuer.getField('CN')?.value || null,
+              notBefore: c.validity.notBefore,
+              notAfter: c.validity.notAfter,
+            };
+          } catch {
+            return null;
+          }
+        }).filter(Boolean);
+        const root = parsed.length ? parsed[parsed.length - 1] : null;
+        chainInfo = { count: parsed.length, entries: parsed, rootCN: root?.issuerCN || root?.subjectCN || null };
+      }
+    } catch {}
+
+    return NextResponse.json({
+      id: ca.id,
+      name: ca.name,
+      subjectDN: ca.subjectDN,
+      status: ca.status,
+      keyAlgorithm: ca.keyAlgorithm,
+      keySize: ca.keySize,
+      curve: ca.curve,
+      validFrom: ca.validFrom,
+      validTo: ca.validTo,
+      crlNumber: ca.crlNumber,
+      crlDistributionPoint: ca.crlDistributionPoint,
+      ocspUrl: ca.ocspUrl,
+      hasCertificate: !!ca.certificate,
+      hasCertificateChain: !!ca.certificateChain,
+      certificateInfo: certInfo,
+      certificateChainInfo: chainInfo,
+    });
+  } catch (error) {
+    console.error('Failed to fetch CA details:', error);
+    return NextResponse.json({ error: 'Failed to fetch CA details' }, { status: 500 });
+  }
+}
 
 export async function DELETE(
   request: Request,

--- a/src/app/ca/[id]/page.tsx
+++ b/src/app/ca/[id]/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Shield, RefreshCw, ArrowLeft, Link as LinkIcon } from 'lucide-react';
+
+export default function CAViewPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { id } = params;
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [ca, setCa] = useState<any>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await fetch(`/api/ca/${id}`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || 'Failed to load CA details');
+        }
+        const data = await res.json();
+        setCa(data);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load CA details');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center justify-center min-h-[300px]">
+          <RefreshCw className="h-8 w-8 animate-spin" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !ca) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Alert>
+          <AlertDescription>{error || 'CA not found'}</AlertDescription>
+        </Alert>
+        <div className="mt-4">
+          <Button variant="outline" onClick={() => router.push('/ca/setup')}>
+            <ArrowLeft className="h-4 w-4 mr-2" /> Back to CA Setup
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Shield className="h-6 w-6" />
+          <h1 className="text-2xl font-bold">CA Details</h1>
+          <Badge variant={ca.status === 'ACTIVE' ? 'default' : 'secondary'}>{ca.status}</Badge>
+        </div>
+        <Button variant="outline" onClick={() => router.push('/ca/setup')}>
+          <ArrowLeft className="h-4 w-4 mr-2" /> Back
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Overview</CardTitle>
+          <CardDescription>Core information about this Certificate Authority</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <div className="text-sm text-gray-500">Name</div>
+              <div className="font-mono text-sm">{ca.name || '-'}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">Subject DN</div>
+              <div className="font-mono text-sm break-words">{ca.subjectDN}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">Validity</div>
+              <div className="text-sm">{ca.validFrom ? new Date(ca.validFrom).toLocaleDateString() : '-'} → {ca.validTo ? new Date(ca.validTo).toLocaleDateString() : '-'}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">Key Algorithm</div>
+              <div className="text-sm">{ca.keyAlgorithm}{ca.keySize ? ` ${ca.keySize}` : ca.curve ? ` ${ca.curve}` : ''}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">CRL Number</div>
+              <div className="text-sm">{ca.crlNumber}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">CRL Distribution Point</div>
+              <div className="font-mono text-xs break-all">{ca.crlDistributionPoint || '-'}</div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-500">OCSP URL</div>
+              <div className="font-mono text-xs break-all">{ca.ocspUrl || '-'}</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Certificate</CardTitle>
+          <CardDescription>Signed CA certificate information</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {ca.certificateInfo ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <div className="text-sm text-gray-500">Subject CN</div>
+                <div className="font-mono text-sm">{ca.certificateInfo.subjectCN || '-'}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Issuer CN</div>
+                <div className="font-mono text-sm">{ca.certificateInfo.issuerCN || '-'}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Self-signed</div>
+                <div className="text-sm">{ca.certificateInfo.selfSigned ? 'Yes' : 'No'}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Valid From</div>
+                <div className="text-sm">{new Date(ca.certificateInfo.notBefore).toLocaleDateString()}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Valid To</div>
+                <div className="text-sm">{new Date(ca.certificateInfo.notAfter).toLocaleDateString()}</div>
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-gray-600">No certificate uploaded yet.</div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Certificate Chain</CardTitle>
+          <CardDescription>Chain entries up to the root (if provided)</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {ca.certificateChainInfo && ca.certificateChainInfo.count > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>#</TableHead>
+                  <TableHead>Subject CN</TableHead>
+                  <TableHead>Issuer CN</TableHead>
+                  <TableHead>Valid From</TableHead>
+                  <TableHead>Valid To</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ca.certificateChainInfo.entries.map((e: any, idx: number) => (
+                  <TableRow key={idx}>
+                    <TableCell>{idx + 1}</TableCell>
+                    <TableCell className="font-mono text-xs">{e.subjectCN || '-'}</TableCell>
+                    <TableCell className="font-mono text-xs">{e.issuerCN || '-'}</TableCell>
+                    <TableCell className="text-xs">{e.notBefore ? new Date(e.notBefore).toLocaleDateString() : '-'}</TableCell>
+                    <TableCell className="text-xs">{e.notAfter ? new Date(e.notAfter).toLocaleDateString() : '-'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="text-sm text-gray-600">No certificate chain uploaded.</div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/app/ca/setup/page.tsx
+++ b/src/app/ca/setup/page.tsx
@@ -313,6 +313,14 @@ export default function CASetupPage() {
                               >
                                 Delete
                               </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="ml-2"
+                                onClick={() => router.push(`/ca/${ca.id}`)}
+                              >
+                                View
+                              </Button>
                               {ca.status === 'INITIALIZING' && (
                                 <Button
                                   size="sm"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API endpoint to retrieve detailed Certificate Authority info, including certificate and chain insights (subject/issuer CNs, validity window, self-signed status, public key type), with clear 401/404/500 responses.
  * Introduced a CA Details page with overview, certificate, and certificate chain sections, plus loading indicators, error alerts, and navigation controls.
  * Added a “View” button in the CA Setup table to quickly navigate to a CA’s details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->